### PR TITLE
Improve alignment speed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ bio = "0.31.0"
 rayon = "1.3.1"
 csv = "1.1.3"
 num_cpus = "1.13.0"
+debruijn = { git = "https://github.com/10XGenomics/rust-debruijn" }
+debruijn_mapping = { git = "https://github.com/10XGenomics/rust-pseudoaligner.git", rev = "ae4aadbce921d3233e3bd9b3ee8a8466804b20ad" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ rayon = "1.3.1"
 csv = "1.1.3"
 num_cpus = "1.13.0"
 debruijn = { git = "https://github.com/10XGenomics/rust-debruijn" }
-debruijn_mapping = { git = "https://github.com/10XGenomics/rust-pseudoaligner.git", rev = "ae4aadbce921d3233e3bd9b3ee8a8466804b20ad" }
+debruijn_mapping = { git = "https://github.com/10XGenomics/rust-pseudoaligner" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 bio = "0.31.0"
-num_cpus = "1.13.0"
 rayon = "1.3.1"
 csv = "1.1.3"
+num_cpus = "1.13.0"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -17,7 +17,7 @@ struct GroupCollapseState {
 pub fn collapse_results_by_lineage<R: Read>(mut reference_library: StringRecordsIntoIter<R>, mut scores: Iter<f32>) -> Vec<(String, f32)> {
   const GROUP_COLUMN: usize = 4;
   const ROUND_FACTOR: f32 = 100000.0;
-
+  
   // Initialize group collapse state manager to the first element of the reference and score iterators
   let mut group_collapse_state = GroupCollapseState {
     results: Vec::new(),
@@ -60,6 +60,7 @@ mod tests {
     #[test]
     fn filter_all_unique_groups() {
       let reference_library_data = "\
+header1\theader2\theader3\theader4\theader5
 test10\ttest11\ttest12\ttest13\ttest14
 test20\ttest21\ttest22\ttest23\ttest24
 test30\ttest31\ttest32\ttest33\ttest34
@@ -85,6 +86,7 @@ test40\ttest41\ttest42\ttest43\ttest44";
     #[test]
     fn filter_single_group() {
       let reference_library_data = "\
+header1\theader2\theader3\theader4\theader5
 test10\ttest11\ttest12\ttest13\ttest
 test20\ttest21\ttest22\ttest23\ttest
 test30\ttest31\ttest32\ttest33\ttest
@@ -107,6 +109,7 @@ test40\ttest41\ttest42\ttest43\ttest";
     #[test]
     fn filter_multiple_groups_same_length() {
       let reference_library_data = "\
+header1\theader2\theader3\theader4\theader5
 test10\ttest11\ttest12\ttest13\ttest1
 test20\ttest21\ttest22\ttest23\ttest1
 test30\ttest31\ttest32\ttest33\ttest2
@@ -133,6 +136,7 @@ test60\ttest61\ttest62\ttest63\ttest3";
     #[test]
     fn filter_multiple_groups_varying_length() {
       let reference_library_data = "\
+header1\theader2\theader3\theader4\theader5
 test10\ttest11\ttest12\ttest13\ttest1
 test20\ttest21\ttest22\ttest23\ttest1
 test30\ttest31\ttest32\ttest33\ttest1

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -13,6 +13,7 @@ struct GroupCollapseState {
  * scores. Collapses the reference score list by merging the scores for by group
  * Returns a score vector with a length equal to the number of groups in the references
  */
+// TODO: Look at using itertools for this
 pub fn collapse_results_by_lineage<R: Read>(mut reference_library: StringRecordsIntoIter<R>, mut scores: Iter<f32>) -> Vec<(String, f32)> {
   const GROUP_COLUMN: usize = 4;
   const ROUND_FACTOR: f32 = 100000.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,82 +5,107 @@ use std::env;
 use std::path;
 use std::fs::File;
 use std::io::prelude::*;
-use rayon::prelude::*;
-use rayon::iter::ParallelBridge;
+//use rayon::prelude::*;
+//use rayon::iter::ParallelBridge;
 use bio::io::fasta;
 use bio::io::fastq;
 use bio::alignment::sparse::hash_kmers;
-use bio::alignment::pairwise::{Scoring,MatchFunc};
+use bio::alignment::pairwise::Scoring;
 use bio::alignment::pairwise::banded::*;
 
 fn main() {
+
+  // TODO: Configure these parameters in the reference library
+  // Aligner parameters
   const K: usize = 6; // kmer match length, used to configure aligners and kmer hashing function
+  const W: usize = 20; // Window size for creating the band
+  const GAP_OPEN: i32 = -3;
+  const GAP_EXTEND: i32 = -1;
+
+  // Filter parameters
   const MATCH_THRESHOLD: i32 = 60; // Threshold to determine whether an alignment is a match
   const REPORT_THRESHOLD: f32 = 0.004; // Number of matches below this value is discarded
+
+  // TODO: Get these from reference library and/or data files
+  const REFERENCE_GENOME_SIZE: usize = 1209;
+  const READS_SIZE: usize = 1;
 
   // TODO: Make this safely parse arguments
   let args: Vec<String> = env::args().collect();
 
-  // Get iterator to records in the reference genome file 
-  // TODO: Make handle FASTQ.gz rather than having to uncompress manually first
-  // TODO: Replace unwraps() with error handling where appropriate
-  let reference_genome = fasta::Reader::from_file(path::Path::new(&args[1])).unwrap().records();
+  // Get iterator to the sequences that will be aligned to the reference from the sequence genome file(s)
+  // TODO: Handle single-end sequences, currently only does paired-end
+  let sequences = fastq::Reader::from_file(path::Path::new(&args[2])).unwrap().records();
+  let reverse_sequences = fastq::Reader::from_file(path::Path::new(&args[3])).unwrap().records();
+  let mut sequences = sequences.zip(reverse_sequences);
 
-  // Parallelized map over the reference library iterator, producing an iterator of score vectors for each reference
-  // TODO: Ensure par_bridge() maintains ordering -- otherwise, rearchitect parallelism
-  let scores = reference_genome.par_bridge().map(|reference| { 
-    // Get the reference and its hash
-    let reference = reference.unwrap();
-    let reference_kmers_hash = hash_kmers(reference.seq(), K);
+  // Subset values for development
+  // TODO: Remove/parameterize this on the console
+  let mut subset_values = Vec::new();
+  for _ in 0..READS_SIZE {
+    subset_values.push(sequences.next().unwrap());
+  }
+  let sequences = subset_values.iter();
 
-    // Get iterators to the sequences that will be aligned to the reference from the sequence genome file(s)
-    // TODO: Handle single-end sequences, currently only does paired-end
-    let sequences = fastq::Reader::from_file(path::Path::new(&args[2])).unwrap().records();
-    let reverse_sequences = fastq::Reader::from_file(path::Path::new(&args[3])).unwrap().records();
+  // Parallelized map over the sequence iterator, producing an iterator of score vectors for each sequence
+  // TODO: Configure parallelism from console arguments
+  let reference_scores = sequences./*par_bridge().*/fold(vec![0.0; REFERENCE_GENOME_SIZE], 
+    |mut acc, (sequence, reverse_sequence)| {
+      // Get iterator to records in the reference genome file 
+      // TODO: Make handle FASTQ.gz rather than having to uncompress manually first
+      // TODO: Replace unwraps() with error handling where appropriate
+      let reference_genome = fasta::Reader::from_file(path::Path::new(&args[1])).unwrap().records();
 
-    // Create banded aligners for the sequence and the reverse sequence
-    let match_fn = |a: u8, b: u8| if a == b { 1 } else { -1 };
-    let mut sequence_aligner = get_mutable_aligner(K, match_fn);
-    let mut reverse_sequence_aligner = get_mutable_aligner(K, match_fn);
+      // Create banded aligner
+      let mut aligner = Aligner::with_scoring(Scoring {
+        gap_open: GAP_OPEN,
+        gap_extend: GAP_EXTEND,
+        match_fn: |a: u8, b: u8| if a == b { 1 } else { -1 },
+        match_scores: Some((1, -1)),
+        xclip_prefix: 0,
+        xclip_suffix: 0,
+        yclip_prefix: 0,
+        yclip_suffix: 0
+      }, K, W);
 
-    // Align the sequence and reverse sequence against the current reference and return an iterator to the scores
-    let sequence_scores = sequences.map(|record| {
-      match record {
-        Ok(seq) => sequence_aligner.custom_with_prehash(seq.seq(), reference.seq(), &reference_kmers_hash).score,
-        Err(_) => 0
+      // Generate score vector for this read
+      let sequence_scores = reference_genome.map(|reference| {
+        // Get the reference and its hash
+        let reference = reference.unwrap();
+        let reference_kmers_hash = hash_kmers(reference.seq(), K);
+
+        // Align the sequence and reverse sequence against the current reference
+        let sequence_score = match sequence {
+          Ok(seq) => aligner.custom_with_prehash(seq.seq(), reference.seq(), &reference_kmers_hash).score,
+          Err(_) => 0
+        };
+
+        let reverse_sequence_score = match reverse_sequence {
+          Ok(seq) => aligner.custom_with_prehash(seq.seq(), reference.seq(), &reference_kmers_hash).score,
+          Err(_) => 0
+        };
+
+        // Return the highest score
+        if sequence_score > reverse_sequence_score { sequence_score } else { reverse_sequence_score }
+      });
+
+      // If there's a score above the match threshold, get all matches >= to that score and mutate the acc vector
+      // TODO: Attach name to reference so we can sort in O(ln) instead of iterating in O(n)
+      let sequence_scores: Vec<i32> = sequence_scores.collect();
+      let max_score = sequence_scores.iter().max().unwrap();
+      if max_score >= &MATCH_THRESHOLD {
+        for (i, v) in sequence_scores.iter().enumerate() {
+          if v >= max_score {
+            acc[i] += 1.0
+          }
+        }
       }
-    });
 
-    let reverse_sequence_scores = reverse_sequences.map(|record| {
-      match record {
-        Ok(seq) => reverse_sequence_aligner.custom_with_prehash(seq.seq(), reference.seq(), &reference_kmers_hash).score,
-        Err(_) => 0
-      }
-    });
-
-    // Concatenate the iterators together
-    let mut scores = sequence_scores.chain(reverse_sequence_scores);
-
-    // Subset the iterator for development
-    // TODO: remove this subsetting after alignment is made more efficient
-    let mut subset_values = Vec::new();
-    for _ in 1..10000 {
-      subset_values.push(scores.next().unwrap());
+      acc
     }
+  );
 
-    subset_values
-  });
-
-  // Run the iterator and collect the values into memory
-  // TODO: Consume lazily so that we're not loading the whole matrix into memory
-  let score_matrix: Vec<Vec<i32>> = scores.collect();
-
-  // Fold the score matrix into a first-pass results matrix
-  let results: Vec<f32> = score_matrix.iter().map(|score_vec| {
-    let score_vec_len = score_vec.len();
-    let ratio = score_vec.iter().fold(0.0, |acc, score| if score >= &MATCH_THRESHOLD { acc+1.0 } else { acc }) / score_vec_len as f32;
-    ratio
-  }).collect();
+  let reference_scores: Vec<f32> = reference_scores.iter().map(|score| score / READS_SIZE as f32).collect();
 
   /* Create reference library iterator and filter results by lineage.
    * 
@@ -91,10 +116,9 @@ fn main() {
    */
   // Get iterator to the reference library
   let reference_library = utils::get_tsv_reader(File::open(path::Path::new(&args[4])).unwrap());
-  let results = filter::collapse_results_by_lineage(reference_library.into_records(), results.iter());
+  let results = filter::collapse_results_by_lineage(reference_library.into_records(), reference_scores.iter());
 
   // Write filtered results to file
-
   let mut str_rep = String::new();
 
   str_rep += "lineage";
@@ -111,45 +135,5 @@ fn main() {
   }
 
   let mut file = File::create("results.tsv").unwrap();
-  file.write_all(str_rep.as_bytes()).unwrap();
-}
-
-// Creates a pre-configured aligner
-fn get_mutable_aligner<F: MatchFunc>(k: usize, function: F) -> Aligner<F> {
-    // Define aligner scoring parameters
-    const W: usize = 20; // Window size for creating the band
-    const GAP_OPEN: i32 = -3;
-    const GAP_EXTEND: i32 = -1;
-
-    let scoring = Scoring {
-      gap_open: GAP_OPEN,
-      gap_extend: GAP_EXTEND,
-      match_fn: function,
-      match_scores: Some((1, -1)),
-      xclip_prefix: 0,
-      xclip_suffix: 0,
-      yclip_prefix: 0,
-      yclip_suffix: 0,
-    };
-
-  /* TODO: We will want to make the choice of global vs local vs semiglobal alignment depend on the reference library
-   * For now, we're running the local banded alignment with hashing.
-   */
-  Aligner::with_scoring(scoring, k, W)
-}
-
-// Convert to TSV and write to disc
-// TODO: Remove this, it's only needed for testing the aligner
-fn _write_alignment_scores_to_tsv(score_matrix: Vec<Vec<i32>>) {
-  let mut str_rep = String::new();
-  for score_vec in score_matrix {
-    for n in score_vec {
-      str_rep += &(n.to_string() + "\t")[..];
-    }
-
-    str_rep += "\n";
-  }
-
-  let mut file = File::create("aligner_score_matrix.tsv").unwrap();
   file.write_all(str_rep.as_bytes()).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,39 +4,60 @@ mod utils;
 use std::env;
 use std::path;
 use std::fs::File;
-use std::io::prelude::*;
-//use rayon::prelude::*;
-//use rayon::iter::ParallelBridge;
+use std::io::Write;
+use std::collections::HashMap;
 use bio::io::fasta;
 use bio::io::fastq;
-use bio::alignment::sparse::hash_kmers;
-use bio::alignment::pairwise::Scoring;
-use bio::alignment::pairwise::banded::*;
+use debruijn::dna_string::DnaString;
+
+type PseudoAligner = debruijn_mapping::pseudoaligner::Pseudoaligner<debruijn::kmer::VarIntKmer<u64, debruijn::kmer::K20>>;
 
 fn main() {
+  // Program parameters
+  // TODO: Get these from the reference library or console
+  const MATCH_THRESHOLD: usize = 60;
+  const NUM_CORES: usize = 4;
 
-  // TODO: Configure these parameters in the reference library
-  // Aligner parameters
-  const K: usize = 6; // kmer match length, used to configure aligners and kmer hashing function
-  const W: usize = 20; // Window size for creating the band
-  const GAP_OPEN: i32 = -3;
-  const GAP_EXTEND: i32 = -1;
-
-  // Filter parameters
-  const MATCH_THRESHOLD: i32 = 60; // Threshold to determine whether an alignment is a match
-  const REPORT_THRESHOLD: f32 = 0.004; // Number of matches below this value is discarded
-
+  // Record sizes
   // TODO: Get these from reference library and/or data files
   const REFERENCE_GENOME_SIZE: usize = 1209;
-  const READS_SIZE: usize = 1;
+  const READS_SIZE: usize = 2786342;
 
   // TODO: Make this safely parse arguments
   let args: Vec<String> = env::args().collect();
 
+  // Get iterators to records in the reference genome file and library
+  // TODO: Make handle FASTQ.gz rather than having to uncompress manually first
+  // TODO: Replace unwraps() with error handling where appropriate
+  let reference_genome = fasta::Reader::from_file(path::Path::new(&args[1])).unwrap().records();
+  let reference_library = utils::get_tsv_reader(File::open(path::Path::new(&args[4])).unwrap());
+
+  // Load reference genome and library into memory
+  let mut reference_seqs = Vec::new();
+  for reference in reference_genome {
+    let reference = reference.unwrap();
+    reference_seqs.push(DnaString::from_acgt_bytes(reference.seq())); // Convert raw data to DNAString
+  }
+  
+  let mut reference_names = Vec::new();
+  for reference in reference_library.into_records() {
+    let reference = reference.unwrap();
+    reference_names.push(reference[0].to_string());
+  }
+
+  // Create debruijn-mapped index of the reference library
+  // TODO: Check ways to make NUM_CORES more effective
+  let reference_index = debruijn_mapping::build_index::build_index::<debruijn_mapping::config::KmerType>(
+    &reference_seqs,
+    &reference_names,
+    &HashMap::new(),
+    NUM_CORES
+  ).unwrap();
+
   // Get iterator to the sequences that will be aligned to the reference from the sequence genome file(s)
   // TODO: Handle single-end sequences, currently only does paired-end
-  let sequences = fastq::Reader::from_file(path::Path::new(&args[2])).unwrap().records();
-  let reverse_sequences = fastq::Reader::from_file(path::Path::new(&args[3])).unwrap().records();
+  let sequences = fastq::Reader::from_file(path::Path::new(&args[2])).unwrap().records().map(|record| DnaString::from_acgt_bytes(record.unwrap().seq()));
+  let reverse_sequences = fastq::Reader::from_file(path::Path::new(&args[3])).unwrap().records().map(|record| DnaString::from_acgt_bytes(record.unwrap().seq()));
   let mut sequences = sequences.zip(reverse_sequences);
 
   // Subset values for development
@@ -47,57 +68,33 @@ fn main() {
   }
   let sequences = subset_values.iter();
 
-  // Parallelized map over the sequence iterator, producing an iterator of score vectors for each sequence
-  // TODO: Configure parallelism from console arguments
-  let reference_scores = sequences./*par_bridge().*/fold(vec![0.0; REFERENCE_GENOME_SIZE], 
+  // Map over the sequence iterator, producing an iterator of score vectors for each sequence
+  let reference_scores = sequences.fold(vec![0.0; REFERENCE_GENOME_SIZE], 
     |mut acc, (sequence, reverse_sequence)| {
-      // Get iterator to records in the reference genome file 
-      // TODO: Make handle FASTQ.gz rather than having to uncompress manually first
-      // TODO: Replace unwraps() with error handling where appropriate
-      let reference_genome = fasta::Reader::from_file(path::Path::new(&args[1])).unwrap().records();
 
-      // Create banded aligner
-      let mut aligner = Aligner::with_scoring(Scoring {
-        gap_open: GAP_OPEN,
-        gap_extend: GAP_EXTEND,
-        match_fn: |a: u8, b: u8| if a == b { 1 } else { -1 },
-        match_scores: Some((1, -1)),
-        xclip_prefix: 0,
-        xclip_suffix: 0,
-        yclip_prefix: 0,
-        yclip_suffix: 0
-      }, K, W);
+      /* Generate score and equivalence class for this read by aligning the sequence and reverse sequence against
+       * the current reference. This alignment returns any scores that are greater than the match threshold. */
+      let seq_score = pseduoalign(&sequence, &reference_index, MATCH_THRESHOLD);
+      let rev_seq_score = pseduoalign(&reverse_sequence, &reference_index, MATCH_THRESHOLD);
 
-      // Generate score vector for this read
-      let sequence_scores = reference_genome.map(|reference| {
-        // Get the reference and its hash
-        let reference = reference.unwrap();
-        let reference_kmers_hash = hash_kmers(reference.seq(), K);
+      // Get the greater of the two scores and the associated equivalence class
+      let mut max_score = 0;
+      let mut max_eqv_class = Vec::new();
+      if let Some((eqv_class, score)) = seq_score {
+        max_score = score;
+        max_eqv_class = eqv_class;
+      } 
 
-        // Align the sequence and reverse sequence against the current reference
-        let sequence_score = match sequence {
-          Ok(seq) => aligner.custom_with_prehash(seq.seq(), reference.seq(), &reference_kmers_hash).score,
-          Err(_) => 0
-        };
+      if let Some((eqv_class, score)) = rev_seq_score {
+        if score > max_score {
+          max_eqv_class = eqv_class;
+        }
+      }
 
-        let reverse_sequence_score = match reverse_sequence {
-          Ok(seq) => aligner.custom_with_prehash(seq.seq(), reference.seq(), &reference_kmers_hash).score,
-          Err(_) => 0
-        };
-
-        // Return the highest score
-        if sequence_score > reverse_sequence_score { sequence_score } else { reverse_sequence_score }
-      });
-
-      // If there's a score above the match threshold, get all matches >= to that score and mutate the acc vector
-      // TODO: Attach name to reference so we can sort in O(ln) instead of iterating in O(n)
-      let sequence_scores: Vec<i32> = sequence_scores.collect();
-      let max_score = sequence_scores.iter().max().unwrap();
-      if max_score >= &MATCH_THRESHOLD {
-        for (i, v) in sequence_scores.iter().enumerate() {
-          if v >= max_score {
-            acc[i] += 1.0
-          }
+      // If there was a match, update the results accordingly
+      if !max_eqv_class.is_empty() {
+        for idx in max_eqv_class {
+          acc[idx as usize] += 1.0;
         }
       }
 
@@ -105,7 +102,8 @@ fn main() {
     }
   );
 
-  let reference_scores: Vec<f32> = reference_scores.iter().map(|score| score / READS_SIZE as f32).collect();
+  // Normalize the results vector down to a percentage
+  let reference_scores: Vec<f32> = reference_scores.iter().map(|score| (score / READS_SIZE as f32) * 100.0).collect();
 
   /* Create reference library iterator and filter results by lineage.
    * 
@@ -114,7 +112,6 @@ fn main() {
    * TODO: This just works based on the grouping string e.g. lineage. There should be some handling
    * after this to heuristically generate names for groups without a name.
    */
-  // Get iterator to the reference library
   let reference_library = utils::get_tsv_reader(File::open(path::Path::new(&args[4])).unwrap());
   let results = filter::collapse_results_by_lineage(reference_library.into_records(), reference_scores.iter());
 
@@ -126,7 +123,7 @@ fn main() {
   str_rep += "percent from locus\n";
 
   for (group, score) in results {
-    if score > REPORT_THRESHOLD {
+    if score > 0.0 {
       str_rep += &group.to_string();
       str_rep += "\t";
       str_rep += &score.to_string();
@@ -136,4 +133,12 @@ fn main() {
 
   let mut file = File::create("results.tsv").unwrap();
   file.write_all(str_rep.as_bytes()).unwrap();
+}
+
+// Align the given sequence against the given reference with a score threshold
+fn pseduoalign(sequence: &DnaString, reference_index: &PseudoAligner, match_threshold: usize) -> Option<(Vec<u32>, usize)> {
+  match reference_index.map_read(&sequence) {
+    Some((equiv_class, score)) => if score >= match_threshold && !equiv_class.is_empty() { Some((equiv_class, score)) } else { None }
+    None => None
+  }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,5 @@ use csv::Reader;
 pub fn get_tsv_reader<R: io::Read>(reader: R) -> Reader<R>{
   csv::ReaderBuilder::new()
     .delimiter(b'\t')
-    .has_headers(false)
     .from_reader(reader)
 }


### PR DESCRIPTION
Fixes #7 and fixes #5 by swapping out the rust-bio aligner with a pseduoaligner. There's still some weirdness around alignment results, but the program runs much faster now.