### PR TITLE
Export ambiguity lists

### DIFF
--- a/src/bin/cli.yml
+++ b/src/bin/cli.yml
@@ -21,10 +21,3 @@ args:
       help: The number of cores to use during alignment
       takes_value: true
       default_value: "1"
-  - debug_reference:
-      short: d
-      long: debug_reference
-      value_name: DEBUG_REFERENCE
-      help: The name of the reference to generate debug information about
-      takes_value: true
-      default_value: ""

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -20,11 +20,9 @@ fn main() {
   let reference_fasta = matches.value_of("reference_fasta").unwrap();
   let input_files: Vec<&str> = matches.values_of("input").unwrap().collect();
   let num_cores = matches.value_of("num_cores").unwrap_or("1").parse::<usize>().expect("Error -- please provide an integer value for the number of cores");
-  let debug_reference = matches.value_of("debug_reference").unwrap_or("");
 
   // Read library alignment config info and reference library metadata from library json
-  let (mut align_config, reference_metadata) = reference_library::get_reference_library(Path::new(reference_json_path));
-  align_config.debug_reference = debug_reference.to_string();
+  let (align_config, reference_metadata) = reference_library::get_reference_library(Path::new(reference_json_path));
 
   // Get iterator to records in the reference genome .fasta
   let reference_genome  = fasta::Reader::from_file(reference_fasta).expect(
@@ -63,7 +61,7 @@ fn main() {
 
   println!("Writing results to file");
 
-  utils::write_to_tsv(results, reference_metadata);
+  utils::write_to_tsv(results);
 
   print!("Output results written to ./results.tsv");
 }

--- a/src/reference_library.rs
+++ b/src/reference_library.rs
@@ -67,8 +67,7 @@ pub fn get_reference_library(path: &Path) -> (align::AlignFilterConfig, Referenc
     discard_nonzero_mismatch: false,
     discard_multiple_matches,
     score_filter: score_filter as i32,
-    intersect_level,
-    debug_reference: String::new()
+    intersect_level
   };
 
 

--- a/src/score.rs
+++ b/src/score.rs
@@ -12,7 +12,7 @@ use debruijn_mapping::pseudoaligner::Pseudoaligner;
  * of the sequences to the reference library. */
 pub fn score<I>(sequences: I, reverse_sequences: Option<I>,
   reference_index: Pseudoaligner<debruijn_mapping::config::KmerType>,
-  reference_metadata: &ReferenceMetadata, align_config: align::AlignFilterConfig) -> Vec<(String, i32, f32)>
+  reference_metadata: &ReferenceMetadata, align_config: align::AlignFilterConfig) -> Vec<(Vec<String>, i32)>
   where 
     I: Iterator<Item = Result<DnaString, Error>>
   {
@@ -21,11 +21,7 @@ pub fn score<I>(sequences: I, reverse_sequences: Option<I>,
   let reference_scores = align::score(sequences, reverse_sequences, reference_index, &reference_metadata, &align_config);
 
   // Remove scores below the score threshold
-  let reference_scores: Vec<(String, i32)> = reference_scores.into_iter().filter(|(_, val)| val > &align_config.score_filter).collect();
+  let reference_scores: Vec<(Vec<String>, i32)> = reference_scores.into_iter().filter(|(_, val)| val > &align_config.score_filter).collect();
 
-  // Append match percentages for each reference result
-  let num_reads: i32 = reference_scores.iter().map(|(_, val)| val).sum();
-  let results = utils::append_match_percent(reference_scores, num_reads as usize);
-
-  utils::sort_score_vector(results)
+  utils::sort_score_vector(reference_scores)
 }

--- a/tests/basic-cases.rs
+++ b/tests/basic-cases.rs
@@ -63,7 +63,7 @@ fn get_group_by_data() -> (Vec<Result<DnaString, Error>>, Pseudoaligner<debruijn
   (sequences, reference_index, reference_metadata)
 }
 
-fn sort_score_vector(mut scores: Vec<(String, i32)>) -> Vec<(String, i32)> {
+fn sort_score_vector(mut scores: Vec<(Vec<String>, i32)>) -> Vec<(Vec<String>, i32)> {
   scores.sort_by(|a, b| a.0.cmp(&b.0));
   scores
 }
@@ -81,18 +81,16 @@ fn basic_single_strand_no_mismatch() {
     discard_nonzero_mismatch: false,
     discard_multiple_matches: false,
     score_filter: 0,
-    intersect_level: IntersectLevel::NoIntersect,
-    debug_reference: String::new()
+    intersect_level: IntersectLevel::NoIntersect
   };
 
   let results = immuno_genotyper::align::score(sequences.into_iter(), None, reference_index, &reference_metadata, &align_config);
   let results = sort_score_vector(results);
 
   let expected_results = vec![
-    (String::from("A02-0"), 2),
-    (String::from("A02-1"), 3),
-    (String::from("A02-2"), 1),
-    (String::from("A02-LC"), 2)];
+    (vec![String::from("A02-0"), String::from("A02-1"), String::from("A02-2"), String::from("A02-LC")], 1),
+    (vec![String::from("A02-0"), String::from("A02-LC")], 1),
+    (vec![String::from("A02-1")], 2)];
   let expected_results = sort_score_vector(expected_results);
 
   assert_eq!(results, expected_results);
@@ -112,18 +110,16 @@ fn basic_single_strand_one_mismatch() {
     discard_nonzero_mismatch: false,
     discard_multiple_matches: false,
     score_filter: 0,
-    intersect_level: IntersectLevel::NoIntersect,
-    debug_reference: String::new()
+    intersect_level: IntersectLevel::NoIntersect
   };
 
   let results = immuno_genotyper::align::score(sequences.into_iter(), None, reference_index, &reference_metadata, &align_config);
   let results = sort_score_vector(results);
 
   let expected_results = vec![
-    (String::from("A02-0"), 2),
-    (String::from("A02-1"), 3),
-    (String::from("A02-2"), 1),
-    (String::from("A02-LC"), 2)];
+    (vec![String::from("A02-0"), String::from("A02-1"), String::from("A02-2"), String::from("A02-LC")], 1),
+    (vec![String::from("A02-0"), String::from("A02-LC")], 1),
+    (vec![String::from("A02-1")], 2)];
   let expected_results = sort_score_vector(expected_results);
 
   assert_eq!(results, expected_results);
@@ -143,18 +139,16 @@ fn basic_single_strand_two_mismatch() {
     discard_nonzero_mismatch: false,
     discard_multiple_matches: false,
     score_filter: 0,
-    intersect_level: IntersectLevel::NoIntersect,
-    debug_reference: String::new()
+    intersect_level: IntersectLevel::NoIntersect
   };
 
   let results = immuno_genotyper::align::score(sequences.into_iter(), None, reference_index, &reference_metadata, &align_config);
   let results = sort_score_vector(results);
 
   let expected_results = vec![
-    (String::from("A02-0"), 2),
-    (String::from("A02-1"), 3),
-    (String::from("A02-2"), 1),
-    (String::from("A02-LC"), 2)];
+    (vec![String::from("A02-0"), String::from("A02-1"), String::from("A02-2"), String::from("A02-LC")], 1),
+    (vec![String::from("A02-0"), String::from("A02-LC")], 1),
+    (vec![String::from("A02-1")], 2)];
   let expected_results = sort_score_vector(expected_results);
 
   assert_eq!(results, expected_results);
@@ -174,16 +168,16 @@ fn group_by() {
     discard_nonzero_mismatch: false,
     discard_multiple_matches: false,
     score_filter: 0,
-    intersect_level: IntersectLevel::NoIntersect,
-    debug_reference: String::new()
+    intersect_level: IntersectLevel::NoIntersect
   };
 
   let results = immuno_genotyper::align::score(sequences.into_iter(), None, reference_index, &reference_metadata, &align_config);
   let results = sort_score_vector(results);
   
   let expected_results = vec![
-    (String::from("g1"), 2),
-    (String::from("g2"), 3)];
+    (vec![String::from("g1")], 1),
+    (vec![String::from("g1"), String::from("g2")], 1),
+    (vec![String::from("g2")], 2)];
   let expected_results = sort_score_vector(expected_results);
 
   assert_eq!(results, expected_results);


### PR DESCRIPTION
Simplify alignment-time filtering and just export a ambiguity list .tsv instead. Also removes the debug command line parameter.